### PR TITLE
Add FAQ entries for mod availability, server support, and supported Minecraft versions

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -32,3 +32,21 @@ Probably 3.8 or higher. But if you have to install it, go straight for 3.13.
 ## ❓️ What is Minescript Plus?
 [https://github.com/R4z0rX/minescript-scripts/tree/main/Minescript-Plus](https://github.com/R4z0rX/minescript-scripts/tree/main/Minescript-Plus)
 
+## ❓️ Where can I download the mod?
+
+- [Modrinth](https://modrinth.com/mod/minescript)  
+- [CurseForge](https://www.curseforge.com/minecraft/mc-mods/minescript)
+
+## ❓️ Can I use it on a server?
+
+Not currently.
+
+## ❓️ What Minecraft versions are supported?
+
+- 1.21.3–1.21.8  
+- 1.21–1.21.1  
+- 1.20.6  
+- 1.20.4  
+- 1.20–1.20.2  
+- 1.19.2–1.19.4  
+- 1.18.2


### PR DESCRIPTION
This PR adds three new entries to the FAQ section:

- Where to download the mod (links to Modrinth and CurseForge)
- Whether the mod can be used on servers (currently not supported)
- A list of supported Minecraft versions

These additions aim to answer common user questions and reduce confusion for new users.